### PR TITLE
Rewrite AMASS preprocessing to accept consolidated motions pickle

### DIFF
--- a/preprocess/amass_utils.py
+++ b/preprocess/amass_utils.py
@@ -3,16 +3,148 @@ import numpy as np
 import os.path as osp
 import torch
 from tqdm import tqdm
+from scipy.interpolate import interp1d
 
 
-
+# Select 24 joints from SMPL-H's 52-joint layout to match SMPL's 24 joints.
+# Joints 0-22 are body joints; joint 37 in SMPL-H = right_index1 = SMPL joint 23.
 joints_to_use = np.array([
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
     11, 12, 13, 14, 15, 16, 17, 18, 19,
     20, 21, 22, 37
 ])
-joints_to_use = np.arange(0,156).reshape((-1,3))[joints_to_use].reshape(-1)
+joints_to_use = np.arange(0, 156).reshape((-1, 3))[joints_to_use].reshape(-1)
 
+
+def resample_sequence(data, source_fps, target_fps):
+    """Resample a sequence from source_fps to target_fps using linear interpolation."""
+    if abs(source_fps - target_fps) < 0.1:
+        return data
+
+    T_src = data.shape[0]
+    duration = T_src / source_fps
+    T_tgt = max(int(round(duration * target_fps)), 2)
+
+    t_src = np.linspace(0, duration, T_src)
+    t_tgt = np.linspace(0, duration, T_tgt)
+
+    original_shape = data.shape
+    data_flat = data.reshape(T_src, -1)
+
+    interp_func = interp1d(t_src, data_flat, axis=0, kind='linear', fill_value='extrapolate')
+    resampled = interp_func(t_tgt)
+
+    return resampled.reshape((T_tgt,) + original_shape[1:])
+
+
+def compute_joint_positions(smpl, pose_chunk, shape_chunk, device, with_shape=True):
+    """
+    Compute SMPL 24-joint positions in body-local frame (zero orient, zero trans).
+
+    Args:
+        smpl: GLAMR SMPL model instance
+        pose_chunk: (T, 72) pose array (24 joints x 3, first 3 = global orient)
+        shape_chunk: (T, 10) shape betas
+        device: torch device
+        with_shape: if True use actual betas, else use zeros
+
+    Returns:
+        joints: (T, 24, 3) joint positions
+    """
+    T = pose_chunk.shape[0]
+    betas = torch.tensor(shape_chunk, device=device, dtype=torch.float32) if with_shape \
+        else torch.zeros((T, 10), device=device, dtype=torch.float32)
+
+    output = smpl(
+        global_orient=torch.zeros((T, 3), device=device, dtype=torch.float32),
+        body_pose=torch.tensor(pose_chunk[:, 3:], device=device, dtype=torch.float32),
+        betas=betas,
+        root_trans=torch.zeros((T, 3), device=device, dtype=torch.float32),
+        orig_joints=True
+    )
+    return output.joints.cpu().numpy()
+
+
+def read_data_from_pkl(motions_list, smpl, device, source_fps=60.0, target_fps=30.0,
+                       min_seq_len=60, max_frames_per_batch=2000):
+    """
+    Read motion data from a consolidated AMASS pickle (list of dicts).
+
+    Each dict in motions_list should have:
+        - 'poses': (T, 156) SMPL-H full pose parameters
+        - 'trans': (T, 3) root translation
+        - 'betas': (>=10,) shape parameters
+        - optionally 'mocap_framerate' to override source_fps per sequence
+
+    Returns:
+        theta_dict:     {seq_name: ndarray(T, 85)}  where 85 = trans(3) + pose(72) + shape(10)
+        joint_pos_dict: {seq_name: (jpos(T,24,3), jpos_noshape(T,24,3))}
+    """
+    theta_dict = {}
+    joint_pos_dict = {}
+
+    for idx, bdata in enumerate(tqdm(motions_list, desc='Processing sequences')):
+        seq_name = f'seq_{idx:06d}'
+
+        poses_full = np.array(bdata['poses'], dtype=np.float64)   # (T, 156)
+        trans = np.array(bdata['trans'], dtype=np.float64)         # (T, 3)
+        betas = np.array(bdata['betas'], dtype=np.float64)
+        betas_10 = betas[:10] if len(betas) >= 10 else np.pad(betas, (0, 10 - len(betas)))
+
+        T = poses_full.shape[0]
+        if T < 10:
+            continue
+
+        # Per-sequence fps override
+        seq_fps = float(bdata.get('mocap_framerate', source_fps))
+
+        # Extract 24-joint pose from SMPL-H 52-joint layout
+        pose = poses_full[:, joints_to_use]   # (T, 72)
+
+        # Resample to target fps
+        if abs(seq_fps - target_fps) > 0.1:
+            pose = resample_sequence(pose, seq_fps, target_fps)
+            trans = resample_sequence(trans, seq_fps, target_fps)
+
+        T = pose.shape[0]
+        if T < min_seq_len:
+            continue
+
+        shape = np.repeat(betas_10[np.newaxis], T, axis=0)  # (T, 10)
+
+        # Compute joint positions in batches
+        all_jpos = []
+        all_jpos_noshape = []
+
+        for start in range(0, T, max_frames_per_batch):
+            end = min(start + max_frames_per_batch, T)
+            chunk_pose = pose[start:end].astype(np.float32)
+            chunk_shape = shape[start:end].astype(np.float32)
+
+            with torch.no_grad():
+                jpos = compute_joint_positions(smpl, chunk_pose, chunk_shape, device, with_shape=True)
+                jpos_noshape = compute_joint_positions(smpl, chunk_pose, chunk_shape, device, with_shape=False)
+
+            all_jpos.append(jpos)
+            all_jpos_noshape.append(jpos_noshape)
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+        joint_pos = np.concatenate(all_jpos, axis=0)            # (T, 24, 3)
+        joint_pos_noshape = np.concatenate(all_jpos_noshape, axis=0)  # (T, 24, 3)
+
+        theta = np.concatenate([trans, pose, shape], axis=1).astype(np.float32)  # (T, 85)
+
+        theta_dict[seq_name] = theta
+        joint_pos_dict[seq_name] = (joint_pos, joint_pos_noshape)
+
+    return theta_dict, joint_pos_dict
+
+
+# ---------------------------------------------------------------------------
+# Legacy API: read from raw AMASS .npz directory structure
+# ---------------------------------------------------------------------------
 
 def read_data(folder, sequences, fps=30, smpl=None, device=torch.device('cpu')):
 
@@ -37,10 +169,10 @@ def read_sequence(folder, seq_name, theta_dict, joint_pos_dict, fps, smpl, devic
 
         for action in actions:
             fname = osp.join(folder, subject, action)
-            
+
             if fname.endswith('shape.npz'):
                 continue
-                
+
             data = np.load(fname)
             mocap_framerate = int(data['mocap_framerate'])
             sampling_freq = mocap_framerate // fps

--- a/preprocess/preprocess_amass.py
+++ b/preprocess/preprocess_amass.py
@@ -1,69 +1,139 @@
-import subprocess
-import glob
+#!/usr/bin/env python3
+"""
+Preprocess a consolidated AMASS motions pickle into the dataset format
+expected by GLAMR's trajectory prediction CVAE (traj_pred/train.py).
+
+Input:
+    --motions_pkl : path to all_motions_fps60.pkl (list of dicts, each with
+                    'poses' (T,156), 'trans' (T,3), 'betas' (>=10,),
+                    and optionally 'mocap_framerate')
+
+Output (written to --output_path):
+    amass_train.pkl       / amass_test.pkl       — theta dicts  {name: (T,85)}
+    amass_train_jpos.pkl  / amass_test_jpos.pkl  — joint pos dicts {name: (jpos, jpos_noshape)}
+
+Requires the SMPL body model files at data/body_models/smpl/ (same model
+used by traj_pred/train.py at training time for consistency).
+
+Usage:
+    cd /path/to/GLAMR
+    python preprocess/preprocess_amass.py \
+        --motions_pkl /path/to/all_motions_fps60.pkl \
+        --output_path datasets/amass_processed/v1 \
+        --source_fps 60 \
+        --target_fps 30 \
+        --train_ratio 0.9
+"""
+
 import os
-import os.path as osp
 import sys
 sys.path.append(os.path.join(os.getcwd()))
+import os.path as osp
 import pickle
-import torch
 import argparse
-from amass_utils import read_data
+import numpy as np
+import torch
+from amass_utils import read_data_from_pkl
 from lib.models.smpl import SMPL, SMPL_MODEL_DIR
 
-parser = argparse.ArgumentParser()
-parser.add_argument('--data_path', default='datasets/amass')
-parser.add_argument('--output_path', default='datasets/amass_processed/v1_new')
-parser.add_argument('--video', action='store_true', default=False)
+
+parser = argparse.ArgumentParser(description='Preprocess consolidated AMASS pickle for GLAMR traj_pred training')
+parser.add_argument('--motions_pkl', required=True,
+                    help='Path to consolidated AMASS motions pickle (e.g. all_motions_fps60.pkl)')
+parser.add_argument('--output_path', default='datasets/amass_processed/v1',
+                    help='Output directory for processed pickle files')
+parser.add_argument('--source_fps', type=float, default=60.0,
+                    help='Default source FPS (overridden per-sequence if mocap_framerate is present)')
+parser.add_argument('--target_fps', type=float, default=30.0,
+                    help='Target FPS for output (GLAMR expects 30)')
+parser.add_argument('--min_seq_len', type=int, default=60,
+                    help='Minimum sequence length after resampling (shorter sequences are dropped)')
+parser.add_argument('--train_ratio', type=float, default=0.9,
+                    help='Fraction of sequences for training (rest goes to test)')
+parser.add_argument('--seed', type=int, default=42,
+                    help='Random seed for train/test split')
+parser.add_argument('--max_frames_per_batch', type=int, default=2000,
+                    help='Max frames per SMPL forward pass (reduce if OOM)')
 args = parser.parse_args()
 
-amass_dir = args.data_path
-processed_dir = args.output_path
-untar_files = False
-os.makedirs(processed_dir, exist_ok=True)
 
+# --- Validate inputs ---
+if not osp.isfile(args.motions_pkl):
+    raise FileNotFoundError(f'Motions pickle not found: {args.motions_pkl}')
 
-if untar_files:
-    files = sorted(glob.glob(f'{amass_dir}/*.tar.bz2'))
-    for fname in files:
-        subprocess.call(['tar', '-xvf', fname, '-C', amass_dir])
+smpl_dir = osp.join(os.getcwd(), SMPL_MODEL_DIR) if not osp.isabs(SMPL_MODEL_DIR) else SMPL_MODEL_DIR
+if not osp.isdir(smpl_dir):
+    raise FileNotFoundError(
+        f'SMPL body model directory not found at {smpl_dir}.\n'
+        f'This is required both for preprocessing and for traj_pred training.\n'
+        f'Please place SMPL model files (SMPL_NEUTRAL.pkl etc.) in {SMPL_MODEL_DIR}/'
+    )
 
+os.makedirs(args.output_path, exist_ok=True)
 
-amass_splits = {
-    'train': [
-        'BMLhandball',
-        'BMLmovi',
-        'BioMotionLab_NTroje',
-        'CMU',
-        'DanceDB',
-        'DFaust_67',
-        'EKUT',
-        'Eyes_Japan_Dataset',
-        'KIT',
-        'MPI_HDM05',
-        'MPI_Limits',
-        'MPI_mosh',
-        'SFU',
-        'TCD_handMocap',
-        'TotalCapture'
-    ],
-    'test': [
-        'Transitions_mocap',
-        'SSM_synced',
-        'HumanEva'
-    ]
-}
+# --- Load input data ---
+print(f'Loading {args.motions_pkl} ...')
+with open(args.motions_pkl, 'rb') as f:
+    motion_data = pickle.load(f)
+print(f'Loaded {len(motion_data)} sequences')
 
-
-device = torch.device('cuda')
+# --- Setup SMPL body model ---
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+print(f'Using device: {device}')
 smpl = SMPL(SMPL_MODEL_DIR, pose_type='body26fk', create_transl=False).to(device)
 
-for split in ['test', 'train']:
-    theta_data, jpos_data = read_data(amass_dir, sequences=amass_splits[split], smpl=smpl, device=device)
+# --- Process all sequences ---
+theta_dict, joint_pos_dict = read_data_from_pkl(
+    motion_data, smpl, device,
+    source_fps=args.source_fps,
+    target_fps=args.target_fps,
+    min_seq_len=args.min_seq_len,
+    max_frames_per_batch=args.max_frames_per_batch,
+)
 
-    theta_data_file = osp.join(processed_dir, f'amass_{split}.pkl')
-    print(f'Saving AMASS dataset (theta) to {theta_data_file}')
-    pickle.dump(theta_data, open(theta_data_file, 'wb'))
+print(f'\nProcessed {len(theta_dict)} valid sequences '
+      f'(dropped {len(motion_data) - len(theta_dict)} short/invalid)')
 
-    jpos_data_file = osp.join(processed_dir, f'amass_{split}_jpos.pkl')
-    print(f'Saving AMASS dataset (joint pos) to {jpos_data_file}')
-    pickle.dump(jpos_data, open(jpos_data_file, 'wb'))
+if len(theta_dict) == 0:
+    print('ERROR: No valid sequences produced. Check input data and min_seq_len.')
+    sys.exit(1)
+
+# --- Split into train / test ---
+seq_names = sorted(theta_dict.keys())
+np.random.seed(args.seed)
+indices = np.random.permutation(len(seq_names))
+split_idx = int(len(indices) * args.train_ratio)
+
+splits = {
+    'train': [seq_names[i] for i in indices[:split_idx]],
+    'test':  [seq_names[i] for i in indices[split_idx:]],
+}
+
+for split_name, split_seqs in splits.items():
+    theta_split = {s: theta_dict[s] for s in split_seqs}
+    jpos_split  = {s: joint_pos_dict[s] for s in split_seqs}
+
+    theta_file = osp.join(args.output_path, f'amass_{split_name}.pkl')
+    jpos_file  = osp.join(args.output_path, f'amass_{split_name}_jpos.pkl')
+
+    print(f'Saving {split_name} ({len(split_seqs)} seqs) -> {theta_file}')
+    with open(theta_file, 'wb') as f:
+        pickle.dump(theta_split, f)
+    print(f'Saving {split_name} jpos -> {jpos_file}')
+    with open(jpos_file, 'wb') as f:
+        pickle.dump(jpos_split, f)
+
+# --- Summary ---
+total_frames = {s: sum(d.shape[0] for d in split.values())
+                for s, split in [('train', {k: theta_dict[k] for k in splits['train']}),
+                                 ('test',  {k: theta_dict[k] for k in splits['test']})]}
+print(f'\n{"="*60}')
+print('PREPROCESSING COMPLETE')
+print(f'{"="*60}')
+print(f'Output directory : {args.output_path}')
+print(f'Target FPS       : {args.target_fps}')
+print(f'Train sequences  : {len(splits["train"])}  ({total_frames["train"]} frames)')
+print(f'Test sequences   : {len(splits["test"])}  ({total_frames["test"]} frames)')
+print(f'\nTo train the trajectory prediction CVAE:')
+print(f'  1. Set amass_dir: {args.output_path}  in traj_pred/cfg/traj_pred_demo.yml')
+print(f'  2. python traj_pred/train.py --cfg traj_pred_demo --ngpus 1')


### PR DESCRIPTION
Rewrites preprocess_amass.py and amass_utils.py to read from a consolidated AMASS pickle (all_motions_fps60.pkl) instead of the raw AMASS .npz directory structure. This matches the data format already available from the MotionBERT/RootNet pipeline.

Key changes:
- New read_data_from_pkl() function that accepts a list of motion dicts (poses, trans, betas, optional mocap_framerate)
- Linear-interpolation resampling (handles non-integer fps ratios)
- Batched SMPL FK to avoid OOM on long sequences
- Configurable train/test split ratio and random seed
- Legacy read_data()/read_sequence() API preserved for backward compat

Output format is unchanged: amass_{split}.pkl (T,85) theta dicts and amass_{split}_jpos.pkl joint position tuples — fully compatible with AMASSDataset and traj_pred/train.py.

https://claude.ai/code/session_016xwCafoEHJZ5zRhkqn9kCb